### PR TITLE
Reshaping function for API and pip instructions for Windows 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,18 @@ ax.quiver(x, y, z, A_x, A_y, A_z, length=5e5, normalize=False, linewidth=2)
 plt.show()
 ```
 
+The default format for exported data is one-dimensional raveled arrays such that a list of tuple representing points in cartesian space is given by
+```
+points = [(x, y, z) for x, y, z in zip(data['fields']['x'], data['fields']['y'], data['fields']['z'])]
+```
+This is the native format of `MagnetiCalc` and is ammenable to use with `quiver`.
+However, for visualising a slice of the magnitude of a field or a field component in a plane and for integrating over the axes it may be preferrable to have
+minimal one-dimensional representations of the axes and the field components arranged in three-dimensional arrays with `axis0 -> x`,  `axis0 -> y`, and  `axis0 -> z`.
+This reformatting if facilitated by
+```
+data_reshape = API.reshape_fields(data)
+```
+
 License
 -------
 Copyright © 2020–2021, Paul Wilhelm, M. Sc. <[anfrage@paulwilhelm.de](mailto:anfrage@paulwilhelm.de)>

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ points = [(x, y, z) for x, y, z in zip(data['fields']['x'], data['fields']['y'],
 ```
 This is the native format of `MagnetiCalc` and is ammenable to use with `quiver`.
 However, for visualising a slice of the magnitude of a field or a field component in a plane and for integrating over the axes it may be preferrable to have
-minimal one-dimensional representations of the axes and the field components arranged in three-dimensional arrays with `axis0 -> x`,  `axis0 -> y`, and  `axis0 -> z`.
+minimal one-dimensional representations of the axes and the field components arranged in three-dimensional arrays with `axis0 -> x`,  `axis1 -> y`, and  `axis2 -> z`.
 This reformatting if facilitated by
 ```
 data_reshape = API.reshape_fields(data)

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ import sys
 ```
 
 ### A-2: Automatic install via pip (Windows 10)
-Tested with Python 3.8.10 (may require [Visual C++ Redistributable Packages for Visual Studio 2017.](https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170) but try without first)
+Tested with Python 3.8.10 (may require [Visual C++ Redistributable Packages for Visual Studio 2017](https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170) but try without first)
 ```shell
 python -m pip install --upgrade pip
 python -m pip install --upgrade scipy
@@ -136,6 +136,7 @@ python -m install --upgrade magneticaclc
 python -m magneticalc
 ```
 **Note:** Installation will succeed without `scipy` installed but the program will crash on `np.dot` due to a dependency for linear algebra.
+
 **Note:** For Python >=3.9 installation will fail because there is not currently an official wheel for `llvmlite` but it might be possible to find an unofficial wheel. This is not recommended.
 
 ### Option B: Manual download

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Screenshot
 
 Installation
 ------------
-Tested with Python 3.8 in Ubuntu 20.04.
+Tested with Python 3.8 in Ubuntu 20.04 and Python 3.7 in Linux Mint 19.3.
 
 If you have trouble installing MagnetiCalc,
 make sure to file an [issue](https://github.com/shredEngineer/MagnetiCalc/issues)
@@ -126,6 +126,17 @@ import sys
 !{sys.executable} -m pip install magneticalc --upgrade
 !{sys.executable} -m magneticalc
 ```
+
+### A-2: Automatic install via pip (Windows 10)
+Tested with Python 3.8.10 (may require [Visual C++ Redistributable Packages for Visual Studio 2017.](https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170) but try without first)
+```shell
+python -m pip install --upgrade pip
+python -m pip install --upgrade scipy
+python -m install --upgrade magneticaclc
+python -m magneticalc
+```
+**Note:** Installation will succeed without `scipy` installed but the program will crash on `np.dot` due to a dependency for linear algebra.
+**Note:** For Python >=3.9 installation will fail because there is not currently an official wheel for `llvmlite` but it might be possible to find an unofficial wheel. This is not recommended.
 
 ### Option B: Manual download
 First, manually install all dependency packages (upgrading each to the latest version):
@@ -199,14 +210,14 @@ plt.show()
 ```
 
 The default format for exported data is one-dimensional raveled arrays such that a list of tuple representing points in cartesian space is given by
-```
+```python
 points = [(x, y, z) for x, y, z in zip(data['fields']['x'], data['fields']['y'], data['fields']['z'])]
 ```
 This is the native format of `MagnetiCalc` and is ammenable to use with `quiver`.
 However, for visualising a slice of the magnitude of a field or a field component in a plane and for integrating over the axes it may be preferrable to have
 minimal one-dimensional representations of the axes and the field components arranged in three-dimensional arrays with `axis0 -> x`,  `axis1 -> y`, and  `axis2 -> z`.
 This reformatting if facilitated by
-```
+```python
 data_reshape = API.reshape_fields(data)
 ```
 

--- a/magneticalc/API.py
+++ b/magneticalc/API.py
@@ -115,3 +115,25 @@ class API:
             else:
                 dictionary[key] = {}
                 API.hdf5_group_to_dict(hdf5_group[key], dictionary[key])
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    
+    @staticmethod
+    def reshape_fields(dictionary) -> Dict:
+        """
+        Reshapes arrays obtained from import_hdf5() so that the axes are given
+        by minimal one-dimensional arrays rather than raveled three-dimensional
+        meshes. The fields are unraveled so that they are represented by
+        three-dimensional arrays with axis0 -> x, axis1 -> y, and axis2 -> z.
+        
+        @param dictionary: Dictionary
+        """
+        axes = ['x','y','z']
+        dictionary2 = dictionary.copy()
+        for key in axes:
+            dictionary2['fields'][key] = np.array(sorted(list(set(dictionary2['fields'][key]))))
+        newShape = (len(dictionary2['fields']['x']),len(dictionary2['fields']['y']),len(dictionary2['fields']['z']))
+        for key in dictionary2['fields']:
+            if not(key in axes):
+                dictionary2['fields'][key] = np.reshape(dictionary2['fields'][key],newShape,order='F')
+        return dictionary2


### PR DESCRIPTION
- Added `reshape_fields` in `magneticalc/API.py` to format data into three-dimesnional arrays.
- Added instructions for installation via pip in Windows 10