### PR TITLE
Bug fix: crash on override padding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 magneticalc/__pycache__/
 .idea/
+magneticalc/QtWidgets2/__pycache__/

--- a/magneticalc/Field.py
+++ b/magneticalc/Field.py
@@ -77,8 +77,8 @@ class Field(Validatable):
         """
         if show_gauss:
             return {
-                FIELD_TYPE_A: "Gs·m",    # Gauss · meter
-                FIELD_TYPE_B: "Gs"       # Gauss
+                FIELD_TYPE_A: "G·m",    # Gauss · meter
+                FIELD_TYPE_B: "G"       # Gauss
             }.get(self.type, ""), 1e4
         else:
             return {

--- a/magneticalc/SamplingVolume_Widget.py
+++ b/magneticalc/SamplingVolume_Widget.py
@@ -266,7 +266,7 @@ class SamplingVolume_Widget(QGroupBox2):
         dialog = OverridePadding_Dialog(self.gui)
         dialog.show()
 
-        if not dialog.success:
+        if not dialog.user_accepted:
             return
 
         # This needlessly also clears the override padding and bounding box settings, but that's acceptable.


### PR DESCRIPTION
The program would crash after any action in the overrid padding dialog. This is now fixed in a0e5a0f.

Additionally, changed symbol for Gauss unit from `Gs` to `G`, which is the standard notation in 4289c21.